### PR TITLE
Fix int const batchCount and add library build option in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Object files
+*.o
+*.lo

--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,32 @@ clean:
 	rm test_kgemm_nn_batched test_kgemm_nt_batched *.o
 	rm test_kronmult6_batched  test_kronmult6_pbatched
 	rm test_kronmult6_xbatched test_kronmult6_vbatched
+	-rm *.o
+	-rm *.lo
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+%.lo: %.cpp
+	$(CXX) $(CXXFLAGS) $(PIC) -c $< -o $@
+
+libname=libkronmult
+ver=0.1.0
+
+static: $(KRONSRC:.cpp=.o)
+	ar qc $(libname).a *.o
+	ranlib $(libname).a
+
+shared: $(KRONSRC:.cpp=.lo)
+	$(LD) $(SHARED) $(SO)$(libname).so.$(ver) -o $(libname).so.$(ver) *.lo $(LIBS)
+
+libs: static shared
+
+PREFIX ?= /usr/local
+install: all libs
+	mkdir -p $(PREFIX}/lib
+	cp $(libname).a $(PREFIX)/lib/
+	cp $(libname).so.$(ver) $(PREFIX)/lib/
+	ln -s $(PREFIX)/lib/$(libname).so.$(ver) $(PREFIX)/lib/$(libname).so
+	mkdir -p $(PREFIX)/bin
+	find * -perm /a=x -exec cp {} $(PREFIX)/bin/ \;

--- a/kronmult2_xbatched.cpp
+++ b/kronmult2_xbatched.cpp
@@ -9,7 +9,7 @@ void kronmult2_xbatched(
                        double* Yarray_[],
                        double* Warray_[],
                        int const batchCount,
-                       int const subbatchCount = 0 )
+                       int subbatchCount = 0 )
 {
         auto max = [](int const x,
                       int const y) -> int {

--- a/kronmult3_xbatched.cpp
+++ b/kronmult3_xbatched.cpp
@@ -9,7 +9,7 @@ void kronmult3_xbatched(
                        double* Yarray_[],
                        double* Warray_[],
                        int const batchCount,
-                       int const subbatchCount = 0 )
+                       int subbatchCount = 0 )
 {
         auto max = [](int const x,
                       int const y) -> int {

--- a/kronmult4_xbatched.cpp
+++ b/kronmult4_xbatched.cpp
@@ -9,7 +9,7 @@ void kronmult4_xbatched(
                        double* Yarray_[],
                        double* Warray_[],
                        int const batchCount,
-                       int const subbatchCount = 0 )
+                       int subbatchCount = 0 )
 {
         auto max = [](int const x,
                       int const y) -> int {

--- a/kronmult5_xbatched.cpp
+++ b/kronmult5_xbatched.cpp
@@ -9,7 +9,7 @@ void kronmult5_xbatched(
                        double* Yarray_[],
                        double* Warray_[],
                        int const batchCount,
-                       int const subbatchCount = 0 )
+                       int subbatchCount = 0 )
 {
         auto max = [](int const x,
                       int const y) -> int {

--- a/kronmult6_xbatched.cpp
+++ b/kronmult6_xbatched.cpp
@@ -9,7 +9,7 @@ void kronmult6_xbatched(
                        double* Yarray_[],
                        double* Warray_[],
                        int const batchCount,
-                       int const subbatchCount = 0 )
+                       int subbatchCount = 0 )
 {
         auto max = [](int const x,
                       int const y) -> int {

--- a/make.inc.gpu
+++ b/make.inc.gpu
@@ -1,5 +1,5 @@
 CXXFLAGS = -DUSE_GPU  -O3
-CXX=nvcc -x cu  -Xcompiler -fopenmp  --gpu-architecture=sm_61  --resource-usage --generate-line-info --maxrregcount 64
+CXX=nvcc -x cu  -Xcompiler -fopenmp  --gpu-architecture=sm_70  --resource-usage --generate-line-info --maxrregcount 64
 PIC=-Xcompiler -fPIC
 LD=g++
 SHARED=-shared

--- a/make.inc.gpu
+++ b/make.inc.gpu
@@ -1,3 +1,6 @@
 CXXFLAGS = -DUSE_GPU  -O3
-CXX=nvcc -x cu  -Xcompiler -fopenmp  --gpu-architecture=sm_70  --resource-usage --generate-line-info --maxrregcount 64
-
+CXX=nvcc -x cu  -Xcompiler -fopenmp  --gpu-architecture=sm_61  --resource-usage --generate-line-info --maxrregcount 64
+PIC=-Xcompiler -fPIC
+LD=g++
+SHARED=-shared
+SO=-Wl,-soname,


### PR DESCRIPTION
Only static version (`libkronmult.a`) works for now. Build with `make static`